### PR TITLE
Mavenize, rename and reorganize build elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 
+target/**
 build/**
 dist/**
 .idea/**

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for Maven, you can add the follwing sections to your POM.XML:
 ## Building
 
 ### Ant
-`ant dist` will build a JAR file suitable for manual inclusion in a project.
+`ant dist` will build a JAR file in the `./dist` suitable for manual inclusion in a project. Dependent libraries are included in `./dist/lib`.
 
 ### Maven
 `mvn package` will build a JAR file with Maven dependency information.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,24 @@ This is the [multihash](https://github.com/multiformats/multihash) implementatio
 Multihash m = Multihash.fromBase58("QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy");
 ```
 
-## Compilation
+## Testing
 
-To compile just run ant.
+### Ant
+`ant test`
+
+### Maven
+`mvn test`
+
+## Building
+
+### Ant
+`ant dist` will build a JAR file suitable for manual inclusion in a project.
+
+### Maven
+`mvn package` will build a JAR file with Maven dependency information.
+
+## Releasing
+The version number is specified in `build.xml` and `pom.xml` and must be changed in both places in order to be accurately reflected in the JAR file manifest.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the [multihash](https://github.com/multiformats/multihash) implementatio
 Multihash m = Multihash.fromBase58("QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy");
 ```
 ## Dependency
-You can use this project by building the JAR file as specified below, or by using [JitPack](https://jitpack.io/#multihash/java-multihash/) (also supporting Gradle, SBT, etc).
+You can use this project by building the JAR file as specified below, or by using [JitPack](https://jitpack.io/#multiformats/java-multihash/) (also supporting Gradle, SBT, etc).
 
 for Maven, you can add the follwing sections to your POM.XML:
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Multihash m = Multihash.fromBase58("QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52v
 ## Dependency
 You can use this project by building the JAR file as specified below, or by using [JitPack](https://jitpack.io/#multihash/java-multihash/) (also supporting Gradle, SBT, etc).
 
-for Maven, you can add to your POM.XML:
+for Maven, you can add the follwing sections to your POM.XML:
+```
   <repositories>
     <repository>
         <id>jitpack.io</id>
@@ -24,11 +25,14 @@ for Maven, you can add to your POM.XML:
     </repository>
   </repositories>
 
-  <dependency>
+  <dependencies>
+    <dependency>
       <groupId>com.github.multiformats</groupId>
       <artifactId>java-multihash</artifactId>
       <version>v1.0.0</version>
-  </dependency>
+    </dependency>
+  </dependencies>
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ This is the [multihash](https://github.com/multiformats/multihash) implementatio
 ```
 Multihash m = Multihash.fromBase58("QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy");
 ```
+## Dependency
+You can use this project by building the JAR file as specified below, or by using [JitPack](https://jitpack.io/#multihash/java-multihash/) (also supporting Gradle, SBT, etc).
+
+for Maven, you can add to your POM.XML:
+  <repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
+  <dependency>
+      <groupId>com.github.multiformats</groupId>
+      <artifactId>java-multihash</artifactId>
+      <version>v1.0.0</version>
+  </dependency>
 
 ## Testing
 
@@ -31,7 +47,7 @@ Multihash m = Multihash.fromBase58("QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52v
 `mvn package` will build a JAR file with Maven dependency information.
 
 ## Releasing
-The version number is specified in `build.xml` and `pom.xml` and must be changed in both places in order to be accurately reflected in the JAR file manifest.
+The version number is specified in `build.xml` and `pom.xml` and must be changed in both places in order to be accurately reflected in the JAR file manifest. A git tag must be added in the format "vx.x.x" for JitPack to work.
 
 ## Maintainers
 

--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
   <target name="compile" depends="init" description="compile the source">
     <javac includeantruntime="false" srcdir="${src}" destdir="${build}" debug="true" debuglevel="lines,vars,source">
       <classpath>
-      	<fileset dir="lib">
+        <fileset dir="lib">
           <include name="**/*.jar" />
         </fileset>
       </classpath>
@@ -50,15 +50,15 @@
     <junit printsummary="yes" fork="true" haltonfailure="yes">
       <jvmarg value="-Xmx1g"/>
       <classpath>
-      	<pathelement location="lib/junit-4.11.jar" />
-      	<pathelement location="lib/hamcrest-core-1.3.jar" />
-      	<pathelement location="multihash.jar" />
+	<pathelement location="lib/junit-4.11.jar" />
+	<pathelement location="lib/hamcrest-core-1.3.jar" />
+	<pathelement location="multihash.jar" />
       </classpath>
-      <test name="io.ipfs.multihash.MultihashTests" haltonfailure="yes">
-				<formatter type="plain"/>
-				<formatter type="xml"/>
+      <test name="io.ipfs.multihash.MultihashTest" haltonfailure="yes">
+	<formatter type="plain"/>
+	<formatter type="xml"/>
       </test>
-      </junit>
+    </junit>
   </target>
 
   <target name="clean" description="clean up">

--- a/build.xml
+++ b/build.xml
@@ -55,8 +55,8 @@
       	<pathelement location="multihash.jar" />
       </classpath>
       <test name="io.ipfs.multihash.MultihashTests" haltonfailure="yes">
-	<formatter type="plain"/>
-	<formatter type="xml"/>
+				<formatter type="plain"/>
+				<formatter type="xml"/>
       </test>
       </junit>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,10 @@
     </manifestclasspath>
     <jar jarfile="${dist}/multihash.jar" basedir="${build}">
       <manifest>
-	  <attribute name="Class-Path" value="${manifest_cp}"/>
+        <attribute name="Class-Path" value="${manifest_cp}"/>
+        <attribute name="Implementation-Vendor" value="io.ipfs"/>
+        <attribute name="Implementation-Title" value="multihash"/>
+        <attribute name="Implementation-Version" value="1.0.0"/>
       </manifest>
     </jar>
     <copy todir=".">

--- a/build.xml
+++ b/build.xml
@@ -43,19 +43,15 @@
         <attribute name="Implementation-Version" value="1.0.0"/>
       </manifest>
     </jar>
-    <copy todir=".">
-      <fileset file="${dist}/multihash.jar"/>
-    </copy>
   </target>
-
 
   <target name="test" depends="compile,dist">
     <junit printsummary="yes" fork="true" haltonfailure="yes">
       <jvmarg value="-Xmx1g"/>
       <classpath>
-	<pathelement location="lib/junit-4.11.jar" />
-	<pathelement location="lib/hamcrest-core-1.3.jar" />
-	<pathelement location="multihash.jar" />
+        <pathelement location="lib/junit-4.11.jar" />
+        <pathelement location="lib/hamcrest-core-1.3.jar" />
+        <pathelement location="dist/multihash.jar" />
       </classpath>
       <test name="io.ipfs.multihash.MultihashTest" haltonfailure="yes">
 	<formatter type="plain"/>

--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
   <target name="compile" depends="init" description="compile the source">
     <javac includeantruntime="false" srcdir="${src}" destdir="${build}" debug="true" debuglevel="lines,vars,source">
       <classpath>
-	<fileset dir="lib">
+      	<fileset dir="lib">
           <include name="**/*.jar" />
         </fileset>
       </classpath>
@@ -35,13 +35,13 @@
     <manifestclasspath property="manifest_cp" jarfile="myjar.jar">
       <classpath refid="dep.runtime" />
     </manifestclasspath>
-    <jar jarfile="${dist}/Multihash.jar" basedir="${build}">
+    <jar jarfile="${dist}/multihash.jar" basedir="${build}">
       <manifest>
 	  <attribute name="Class-Path" value="${manifest_cp}"/>
       </manifest>
     </jar>
     <copy todir=".">
-      <fileset file="${dist}/Multihash.jar"/>
+      <fileset file="${dist}/multihash.jar"/>
     </copy>
   </target>
 
@@ -50,11 +50,11 @@
     <junit printsummary="yes" fork="true" haltonfailure="yes">
       <jvmarg value="-Xmx1g"/>
       <classpath>
-	<pathelement location="lib/junit-4.11.jar" />
-	<pathelement location="lib/hamcrest-core-1.3.jar" />
-	<pathelement location="Multihash.jar" />
+      	<pathelement location="lib/junit-4.11.jar" />
+      	<pathelement location="lib/hamcrest-core-1.3.jar" />
+      	<pathelement location="multihash.jar" />
       </classpath>
-      <test name="org.ipfs.api.MultihashTests" haltonfailure="yes">
+      <test name="io.ipfs.multihash.MultihashTests" haltonfailure="yes">
 	<formatter type="plain"/>
 	<formatter type="xml"/>
       </test>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,79 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.ipfs</groupId>
+	<artifactId>multihash</artifactId>
+	<version>1.0.0</version>
+	<packaging>jar</packaging>
+
+	<name>multihash</name>
+	<url>https://github.com/multiformats/java-multihash</url>
+
+  <issueManagement>
+    <url>https://github.com/multiformats/java-multihash/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <scm>
+    <url>https://github.com/multiformats/java-multihash</url>
+    <connection>scm:git:git://github.com/multiformats/java-multihash.git</connection>
+    <developerConnection>scm:git:git@github.com:multiformats/java-multihash.git</developerConnection>
+  </scm>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://github.com/multiformats/java-multiaddr/blob/master/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<junit.version>4.12</junit.version>
+		<hamcrest.version>1.3</hamcrest.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<version>${hamcrest.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,24 +10,24 @@
 	<name>multihash</name>
 	<url>https://github.com/multiformats/java-multihash</url>
 
-  <issueManagement>
-    <url>https://github.com/multiformats/java-multihash/issues</url>
-    <system>GitHub Issues</system>
-  </issueManagement>
+ 	<issueManagement>
+ 		<url>https://github.com/multiformats/java-multihash/issues</url>
+ 		<system>GitHub Issues</system>
+ 	</issueManagement>
 
-  <scm>
-    <url>https://github.com/multiformats/java-multihash</url>
-    <connection>scm:git:git://github.com/multiformats/java-multihash.git</connection>
-    <developerConnection>scm:git:git@github.com:multiformats/java-multihash.git</developerConnection>
-  </scm>
+ 	<scm>
+ 		<url>https://github.com/multiformats/java-multihash</url>
+ 		<connection>scm:git:git://github.com/multiformats/java-multihash.git</connection>
+ 		<developerConnection>scm:git:git@github.com:multiformats/java-multihash.git</developerConnection>
+ 	</scm>
 
-  <licenses>
-    <license>
-      <name>MIT License</name>
-      <url>https://github.com/multiformats/java-multiaddr/blob/master/LICENSE</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+ 	<licenses>
+ 		<license>
+ 			<name>MIT License</name>
+ 			<url>https://github.com/multiformats/java-multiaddr/blob/master/LICENSE</url>
+ 			<distribution>repo</distribution>
+ 		</license>
+ 	</licenses>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.0.2</version>
 				<configuration>

--- a/src/main/java/io/ipfs/multihash/Base58.java
+++ b/src/main/java/io/ipfs/multihash/Base58.java
@@ -1,4 +1,4 @@
-package org.ipfs.api;
+package io.ipfs.multihash;
 
 /**
  * Copyright 2011 Google Inc.

--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -1,4 +1,4 @@
-package org.ipfs.api;
+package io.ipfs.multihash;
 
 import java.io.*;
 import java.util.*;

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -4,7 +4,7 @@ import org.junit.*;
 
 import java.util.*;
 
-public class MultihashTests {
+public class MultihashTest {
 
     @Test
     public void base58Test() {

--- a/src/test/java/io/ipfs/multihash/MultihashTests.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTests.java
@@ -1,4 +1,4 @@
-package org.ipfs.api;
+package io.ipfs.multihash;
 
 import org.junit.*;
 


### PR DESCRIPTION
As per discussion in [ipfs/java-ipfs-api #1](https://github.com/ipfs/java-ipfs-api/issues/1)

* Added Maven support while maintaining Ant support
* Class hierarchy renamed as per discussion in https://github.com/ipfs/java-ipfs-api/issues/1
* Added version metadata to the JAR files produced by Ant
* Ant dependency & build cleanup

**After merging, a new release tag needs to be created "v1.0.0" for JitPack to work.**