### PR TITLE
Bug fix on toHex(); add tests; fix deprecated hash name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19.1</version>
+				<configuration>
+					<!-- Sets the VM argument line used when unit tests are run. -->
+					<argLine>${surefireArgLine}</argLine>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -90,6 +94,49 @@
 						</manifest>
 					</archive>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.7.8</version>
+				<executions>
+					<!--
+					Prepares the property pointing to the JaCoCo runtime agent which
+					is passed as VM argument when Maven the Surefire plugin is executed.
+					-->
+					<execution>
+						<id>pre-unit-test</id>
+						<goals>
+						<goal>prepare-agent</goal>
+			            		</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+							<destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
+							<!--
+							Sets the name of the property containing the settings
+							for JaCoCo runtime agent.
+							-->
+							<propertyName>surefireArgLine</propertyName>
+						</configuration>
+					</execution>
+					<!--
+					Ensures that the code coverage report for unit tests is created after
+					unit tests have been run.
+					-->
+					<execution>
+						<id>post-unit-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+							<dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
+							<!-- Sets the output directory for the code coverage report. -->
+							<outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19.1</version>
-				<configuration>
-					<!-- Sets the VM argument line used when unit tests are run. -->
-					<argLine>${surefireArgLine}</argLine>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,49 +95,6 @@
 					</archive>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.8</version>
-				<executions>
-					<!--
-					Prepares the property pointing to the JaCoCo runtime agent which
-					is passed as VM argument when Maven the Surefire plugin is executed.
-					-->
-					<execution>
-						<id>pre-unit-test</id>
-						<goals>
-						<goal>prepare-agent</goal>
-			            		</goals>
-						<configuration>
-							<!-- Sets the path to the file which contains the execution data. -->
-							<destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-							<!--
-							Sets the name of the property containing the settings
-							for JaCoCo runtime agent.
-							-->
-							<propertyName>surefireArgLine</propertyName>
-						</configuration>
-					</execution>
-					<!--
-					Ensures that the code coverage report for unit tests is created after
-					unit tests have been run.
-					-->
-					<execution>
-						<id>post-unit-test</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-						<configuration>
-							<!-- Sets the path to the file which contains the execution data. -->
-							<dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
-							<!-- Sets the output directory for the code coverage report. -->
-							<outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -92,11 +92,17 @@ public class Multihash {
         return Arrays.hashCode(hash) ^ type.hashCode();
     }
 
+    final protected static char[] hexArray = "0123456789ABCDEF".toCharArray();
+
     public String toHex() {
-        StringBuilder res = new StringBuilder();
-        for (byte b: toBytes())
-            res.append(String.format("%x", b&0xff));
-        return res.toString();
+        byte[] bytes = toBytes();
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
     }
 
     public String toBase58() {

--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -10,7 +10,7 @@ public class Multihash {
         sha1(0x11, 20),
         sha2_256(0x12, 32),
         sha2_512(0x13, 64),
-        sha3(0x14, 64),
+        sha3_512(0x14, 64),
         blake2b(0x40, 64),
         blake2s(0x41, 32);
 

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -23,19 +23,19 @@ public class MultihashTest {
     public void multihashTest() {
         Object[][] examples = new Object[][]{
             {Multihash.Type.sha1, "SHA-1", "5drNu81uhrFLRiS4bxWgAkpydaLUPW", "hello world"},
-            {Multihash.Type.sha2_256, "SHA2-256", "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4", "hello world"},
-            {Multihash.Type.sha2_512, "SHA2-512", "8Vtkv2tdQ43bNGdWN9vNx9GVS9wrbXHk4ZW8kmucPmaYJwwedXir52kti9wJhcik4HehyqgLrQ1hBuirviLhxgRBNv", "hello world"},
-            {Multihash.Type.sha3_512, "SHA3-512", "8tWhXW5oUwtPd9d3FnjuLP1NozN3vc45rmsoWEEfrZL1L6gi9dqi1YkZu5iHb2HJ8WbZaaKAyNWWRAa8yaxMkGKJmX", "hello world"},
+            {Multihash.Type.sha2_256, "SHA-256", "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4", "hello world"},
+            {Multihash.Type.sha2_512, "SHA-512", "8Vtkv2tdQ43bNGdWN9vNx9GVS9wrbXHk4ZW8kmucPmaYJwwedXir52kti9wJhcik4HehyqgLrQ1hBuirviLhxgRBNv", "hello world"}
+// SHA3 not yet implemented in standard Java library. https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#MessageDigest
+//            {Multihash.Type.sha3_512, "SHA3-512", "8tWhXW5oUwtPd9d3FnjuLP1NozN3vc45rmsoWEEfrZL1L6gi9dqi1YkZu5iHb2HJ8WbZaaKAyNWWRAa8yaxMkGKJmX", "hello world"}
         };
 
         for(Object[] ex: examples) {
             Multihash m = Multihash.fromBase58((String)ex[2]);
             try {
-                // Make sure the hashes agree
-                MessageDigest md = MessageDigest.getInstance((String) ex[3]);
+                MessageDigest md = MessageDigest.getInstance((String) ex[1]);
+                assert(md != null);
                 md.update(((String) ex[3]).getBytes("UTF-8"));
                 byte[] digest = md.digest();
-                assert(Arrays.equals(m.toBytes(), digest));
                 // Test constructor
                 Multihash m2 = new Multihash((Multihash.Type)ex[0], digest);
                 // Test comparison
@@ -45,6 +45,9 @@ public class MultihashTest {
                 assert(m.toBase58().equals((String)ex[2]));
             }
             catch (Exception e){
+                // Usually because a hash function not supported
+                System.out.println(e.getMessage());
+                assert(false);
             }
         }
     }

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -4,6 +4,8 @@ import org.junit.*;
 import io.ipfs.multibase.*;
 import java.util.*;
 import java.security.MessageDigest;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 
 public class MultihashTest {
 
@@ -43,9 +45,11 @@ public class MultihashTest {
                 // Test conversions
                 assert(m.toBase58().equals(m2.toBase58()));
                 assert(m.toBase58().equals((String)ex[2]));
+                // Test fromHex and toHex
+                Multihash m3 = Multihash.fromHex(m.toHex());
+                assert(m3.equals(m));
             }
             catch (Exception e){
-                // Usually because a hash function not supported
                 System.out.println(e.getMessage());
                 assert(false);
             }

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -3,6 +3,7 @@ package io.ipfs.multihash;
 import org.junit.*;
 import io.ipfs.multibase.*;
 import java.util.*;
+import java.security.MessageDigest;
 
 public class MultihashTest {
 
@@ -15,6 +16,36 @@ public class MultihashTest {
             String encoded = Base58.encode(output);
             if (!encoded.equals(example))
                 throw new IllegalStateException("Incorrect base58! " + example + " => " + encoded);
+        }
+    }
+
+    @Test
+    public void multihashTest() {
+        Object[][] examples = new Object[][]{
+            {Multihash.Type.sha1, "SHA-1", "5drNu81uhrFLRiS4bxWgAkpydaLUPW", "hello world"},
+            {Multihash.Type.sha2_256, "SHA2-256", "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4", "hello world"},
+            {Multihash.Type.sha2_512, "SHA2-512", "8Vtkv2tdQ43bNGdWN9vNx9GVS9wrbXHk4ZW8kmucPmaYJwwedXir52kti9wJhcik4HehyqgLrQ1hBuirviLhxgRBNv", "hello world"},
+            {Multihash.Type.sha3_512, "SHA3-512", "8tWhXW5oUwtPd9d3FnjuLP1NozN3vc45rmsoWEEfrZL1L6gi9dqi1YkZu5iHb2HJ8WbZaaKAyNWWRAa8yaxMkGKJmX", "hello world"},
+        };
+
+        for(Object[] ex: examples) {
+            Multihash m = Multihash.fromBase58((String)ex[2]);
+            try {
+                // Make sure the hashes agree
+                MessageDigest md = MessageDigest.getInstance((String) ex[3]);
+                md.update(((String) ex[3]).getBytes("UTF-8"));
+                byte[] digest = md.digest();
+                assert(Arrays.equals(m.toBytes(), digest));
+                // Test constructor
+                Multihash m2 = new Multihash((Multihash.Type)ex[0], digest);
+                // Test comparison
+                assert(m2.equals(m));
+                // Test conversions
+                assert(m.toBase58().equals(m2.toBase58()));
+                assert(m.toBase58().equals((String)ex[2]));
+            }
+            catch (Exception e){
+            }
         }
     }
 }

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -13,7 +13,7 @@ public class MultihashTest {
         for (String example: examples) {
             byte[] output = Base58.decode(example);
             String encoded = Base58.encode(output);
-            if (!encoded.equals(encoded))
+            if (!encoded.equals(example))
                 throw new IllegalStateException("Incorrect base58! " + example + " => " + encoded);
         }
     }

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -4,8 +4,6 @@ import org.junit.*;
 import io.ipfs.multibase.*;
 import java.util.*;
 import java.security.MessageDigest;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 
 public class MultihashTest {
 


### PR DESCRIPTION
`toHex()` has a bug where it produces an odd number of characters.  I wrote tests to demonstrate the problem and fixed it.  I elected to use [this solution](http://stackoverflow.com/questions/9655181/how-to-convert-a-byte-array-to-a-hex-string-in-java) rather than pulling in another dependency.

I introduced tests to exercise the Java-supported SHA-1 and SHA-2 hash functions.  This brings code coverage to around 58%.

The name `sha3` for SHA3-512 used in this library has been [deprecated](https://github.com/multiformats/multihash#table-for-multihash-v100-rc-semver) in [multiformats/multihash](https://github.com/multiformats/multihash/blob/master/hashtable.csv) so I updated it to match the spec. Although this is technically a breaking change I couldn't find anyplace in the ipfs/ipld/multiformats libraries (or anywhere else) that this constant is currently being used. Since this hash function isn't yet available in `java.security` it is commented out of the tests.

The existing test Base58 test (which was a holdover from before multibase was split out) didn't actually do anything, so I changed it to at least compare the results from the library call correctly.