### PR TITLE
Add MD5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ for Maven, you can add the follwing sections to your POM.XML:
     <dependency>
       <groupId>com.github.multiformats</groupId>
       <artifactId>java-multihash</artifactId>
-      <version>v1.1.0</version>
+      <version>v1.2.0</version>
     </dependency>
   </dependencies>
 ```

--- a/build.xml
+++ b/build.xml
@@ -40,7 +40,7 @@
         <attribute name="Class-Path" value="${manifest_cp}"/>
         <attribute name="Implementation-Vendor" value="io.ipfs"/>
         <attribute name="Implementation-Title" value="multihash"/>
-        <attribute name="Implementation-Version" value="1.1.0"/>
+        <attribute name="Implementation-Version" value="1.2.0"/>
       </manifest>
     </jar>
   </target>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>io.ipfs</groupId>
 	<artifactId>multihash</artifactId>
-	<version>1.1.0</version>
+	<version>1.2.0</version>
 	<packaging>jar</packaging>
 
 	<name>multihash</name>

--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -7,6 +7,7 @@ import java.util.*;
 
 public class Multihash {
     public enum Type {
+        md5(0xd5, 16),
         sha1(0x11, 20),
         sha2_256(0x12, 32),
         sha2_512(0x13, 64),

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -22,6 +22,7 @@ public class MultihashTest {
     @Test
     public void multihashTest() {
         Object[][] examples = new Object[][]{
+            {Multihash.Type.md5, "MD5", "9qZY4e2uauH3bG83FdaPSaPzA", "hello world"},
             {Multihash.Type.sha1, "SHA-1", "5drNu81uhrFLRiS4bxWgAkpydaLUPW", "hello world"},
             {Multihash.Type.sha2_256, "SHA-256", "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4", "hello world"},
             {Multihash.Type.sha2_512, "SHA-512", "8Vtkv2tdQ43bNGdWN9vNx9GVS9wrbXHk4ZW8kmucPmaYJwwedXir52kti9wJhcik4HehyqgLrQ1hBuirviLhxgRBNv", "hello world"}


### PR DESCRIPTION
* Add MD5 support.
* Bump version to 1.2.0

Note: MD5 is a deprecated (like SHA-1) hash function which is no longer useful for cryptographic purposes, but is commonly used for other purposes.
