### PR TITLE
Get hash method & more hash-types

### DIFF
--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -70,7 +70,9 @@ public class Multihash {
     }
 
     public byte[] getHash() {
-        return hash;
+        byte[] res = new byte[hash.length]
+        System.arraycopy(hash, 0, res, 0, hash.length);
+        return res;
     }
 
     public void serialize(DataOutput dout) throws IOException {

--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -70,8 +70,7 @@ public class Multihash {
     }
 
     public byte[] getHash() {
-        byte[] res = new byte[hash.length];
-        System.arraycopy(hash, 0, res, 0, hash.length);
+        byte[] res = Arrays.copyOf(hash)
         return res;
     }
 

--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -70,7 +70,7 @@ public class Multihash {
     }
 
     public byte[] getHash() {
-        byte[] res = new byte[hash.length]
+        byte[] res = new byte[hash.length];
         System.arraycopy(hash, 0, res, 0, hash.length);
         return res;
     }

--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -11,7 +11,13 @@ public class Multihash {
         sha1(0x11, 20),
         sha2_256(0x12, 32),
         sha2_512(0x13, 64),
+        sha3_224(0x17, 24),
+        sha3_256(0x16, 32),
         sha3_512(0x14, 64),
+        keccak_224(0x1a, 24),
+        keccak_256(0x1b, 32),
+        keccak_384(0x1c, 48),
+        keccak_512(0x1d, 64),
         blake2b(0x40, 64),
         blake2s(0x41, 32);
 
@@ -61,6 +67,10 @@ public class Multihash {
         res[1] = (byte)hash.length;
         System.arraycopy(hash, 0, res, 2, hash.length);
         return res;
+    }
+
+    public byte[] getHash() {
+        return hash;
     }
 
     public void serialize(DataOutput dout) throws IOException {


### PR DESCRIPTION
- Added getHash method
motivation:
Useful for decoding the pure hash and storing to blockchains such as ethereum

- Added more hash-types
motivation:
A lot of hash-types are missing