### PR TITLE
2X faster lookup: s/TreeMap/HashMap and kill containsKey

### DIFF
--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -8,8 +8,8 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 public class Multihash {
     public enum Type {
@@ -35,16 +35,17 @@ public class Multihash {
             this.length = length;
         }
 
-        private static Map<Integer, Type> lookup = new TreeMap<>();
+        private static Map<Integer, Type> lookup = new HashMap<>();
         static {
             for (Type t: Type.values())
                 lookup.put(t.index, t);
         }
 
         public static Type lookup(int t) {
-            if (!lookup.containsKey(t))
+            Type type = lookup.get(t);
+            if (type == null)
                 throw new IllegalStateException("Unknown Multihash type: "+t);
-            return lookup.get(t);
+            return type;
         }
 
     }


### PR DESCRIPTION
Invoked both in construction and deserialize. I have full benchmarks since I thought backing data will be good for coverage and completeness. The general gist is `containsKey` is redundant since we know the lookup table cannot contain null types with all initialization happening in a static initializer.

## Benchmarks

See https://github.com/vkarun/enum-reverse-lookup-table-jmh

```java
       // t1
        static Type lookupTreeMapNotContainsKeyThrowGet(int t) {
            if (!lookupT.containsKey(t))
                throw new IllegalStateException("Unknown Multihash type: " + t);
            return lookupT.get(t);
        }
        // t2
        static Type lookupTreeMapGetThrowIfNull(int t) {
            Type type = lookupT.get(t);
            if (type == null)
                throw new IllegalStateException("Unknown Multihash type: " + t);
            return type;
        }
        // t3
        static Type lookupTreeMapGetOptionalOrElseThrow(int t) {
            return Optional.ofNullable(lookupT.get(t)).orElseThrow(() -> new IllegalStateException("Unknown Multihash type: " + t));
        }
        // h1
        static Type lookupHashMapNotContainsKeyThrowGet(int t) {
            if (!lookupH.containsKey(t))
                throw new IllegalStateException("Unknown Multihash type: " + t);
            return lookupH.get(t);
        }
        // h2
        static Type lookupHashMapGetThrowIfNull(int t) {
            Type type = lookupH.get(t);
            if (type == null)
                throw new IllegalStateException("Unknown Multihash type: " + t);
            return type;
        }
        // h3
        static Type lookupHashMapGetOptionalOrElseThrow(int t) {
            return Optional.ofNullable(lookupH.get(t)).orElseThrow(() -> new IllegalStateException("Unknown Multihash type: " + t));
        }
    }
```

h2 is the clear winner and t1 is the slowest.

- A `HashMap` uses a O(1) constant table lookup whereas a `TreeMap` uses a O(log(n)) lookup and this manifests in the average time below.

- `containsKey` followed by a `get` is redundant and has a non-trivial performance penalty if we know that null values will never be permitted as is the case here since all values are put only in the static initialization block.

```sh
Benchmark                                (iterations)  (lookupApproach)  Mode  Cnt   Score   Error  Units

MultihashTypeLookupBenchmark.testLookup          1000                t1  avgt    9  33.438 ± 4.514  us/op
MultihashTypeLookupBenchmark.testLookup          1000                t2  avgt    9  26.986 ± 0.405  us/op
MultihashTypeLookupBenchmark.testLookup          1000                t3  avgt    9  39.259 ± 1.306  us/op
MultihashTypeLookupBenchmark.testLookup          1000                h1  avgt    9  18.954 ± 0.414  us/op
MultihashTypeLookupBenchmark.testLookup          1000                h2  avgt    9  15.486 ± 0.395  us/op
MultihashTypeLookupBenchmark.testLookup          1000                h3  avgt    9  16.780 ± 0.719  us/op
```

### Verified

![screenshot from 2018-10-05 21-27-46](https://user-images.githubusercontent.com/6547711/46565414-863cd600-c8e5-11e8-8e24-6dec2f70d597.png)

### TreeMap source reference

https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/util/TreeMap.java

![treemap-containskey](https://user-images.githubusercontent.com/6547711/46565418-91900180-c8e5-11e8-8085-5a3e82e53b03.png)

![tree-map-get](https://user-images.githubusercontent.com/6547711/46565424-9fde1d80-c8e5-11e8-845e-d5c220db3d01.png)

![treemap-getentry](https://user-images.githubusercontent.com/6547711/46565422-981e7900-c8e5-11e8-8865-8d3aa9e469a7.png)

### HashMap source reference

https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/util/HashMap.java

![haspmap-containskey](https://user-images.githubusercontent.com/6547711/46565427-a5d3fe80-c8e5-11e8-9a4f-598a2c2d8c8f.png)

![hash_map_get](https://user-images.githubusercontent.com/6547711/46565430-acfb0c80-c8e5-11e8-8c4d-b0947f33abd4.png)

