### PR TITLE
Print the unknown multihash code in hexadecimal.

### DIFF
--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -144,7 +144,7 @@ public class Multihash {
         public static Type lookup(int t) {
             Type type = lookup.get(t);
             if (type == null)
-                throw new IllegalStateException("Unknown Multihash type: "+t);
+                throw new IllegalStateException(String.format("Unknown Multihash type: 0x%x", t));
             return type;
         }
 


### PR DESCRIPTION
The hexadecimal code is easier to compare with the [source code](https://github.com/multiformats/java-multihash/blob/master/src/main/java/io/ipfs/multihash/Multihash.java#L13) and the official [code table](https://github.com/multiformats/multicodec/blob/master/table.csv).

The error will look like this:
```
java.lang.IllegalStateException: Unknown Multihash type: 0x54
```