### PR TITLE
Updated the version of JDK used in the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11


### PR DESCRIPTION
Travis [ceased](https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8) to support Oracle JDK 8.