### PR TITLE
Fix Multihash.Type.hashCode()

### DIFF
--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -148,6 +148,10 @@ public class Multihash {
             return type;
         }
 
+        @Override
+        public int hashCode() {
+            return index;
+        }
     }
 
     private final Type type;


### PR DESCRIPTION
Given that Multihash.hashCode() invokes Multihash.hashCode(), and e.g. https://madhead.me/posts/enums-fuckup/, this seems more appropriate.