### PR TITLE
Remove Multihash.bareMultihash()

### DIFF
--- a/src/main/java/io/ipfs/multihash/Multihash.java
+++ b/src/main/java/io/ipfs/multihash/Multihash.java
@@ -198,10 +198,6 @@ public class Multihash {
         }
     }
 
-    public Multihash bareMultihash() {
-        return this;
-    }
-
     public static Multihash deserialize(InputStream din) throws IOException {
         int type = (int)readVarint(din);
         int len = (int)readVarint(din);


### PR DESCRIPTION
It just returns "this", which seems pointless? (At least without a JavaDoc which describes what the point of this method may be.)