### PR TITLE
Migrate JUnit4 -> JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.junit>4.13.2</version.junit>
-        <version.hamcrest>2.2</version.hamcrest>
+		<version.junit>5.11.0</version.junit>
+        <version.hamcrest>3.0</version.hamcrest>
         <version.multibase>v1.1.1</version.multibase>
 	</properties>
 
@@ -51,8 +51,8 @@
             <version>${version.multibase}</version>
         </dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<version>${version.junit}</version>
 			<scope>test</scope>
 		</dependency>
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>3.3.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/io/ipfs/multihash/MultihashTest.java
+++ b/src/test/java/io/ipfs/multihash/MultihashTest.java
@@ -1,19 +1,19 @@
 package io.ipfs.multihash;
 
 import io.ipfs.multibase.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class MultihashTest {
+class MultihashTest {
 
     @Test
-    public void base58Test() {
+    void base58Test() {
         List<String> examples = Arrays.asList("QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB",
                 "QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy");
         for (String example: examples) {
@@ -24,7 +24,7 @@ public class MultihashTest {
     }
 
     @Test
-    public void decodeTest() throws IOException {
+    void decodeTest() throws IOException {
         List<String> base58 = Arrays.asList(
                 "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB",
                 "QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy"
@@ -40,7 +40,7 @@ public class MultihashTest {
     }
 
     @Test
-    public void multihashTest() {
+    void multihashTest() {
         Object[][] examples = new Object[][]{
             {Multihash.Type.id, "ID", "13hC12xCn", "hello"},
             {Multihash.Type.id, "ID", "11", ""},


### PR DESCRIPTION
The JUnit5 framework is the successor to JUnit4, and is currently maintained version.
Changes in this PR:
- Tests migrated from JUnit4 to JUnit5 using OpenRewrite
- Dependencies updated